### PR TITLE
[bug] 'time_created' integer overflow FC

### DIFF
--- a/BetterBatteryStats/src/com/asksven/betterbatterystats/data/ReferenceDBHelper.java
+++ b/BetterBatteryStats/src/com/asksven/betterbatterystats/data/ReferenceDBHelper.java
@@ -348,7 +348,7 @@ public class ReferenceDBHelper
 		        for (int i = 0; i < numRows; ++i)
 		        {
 		        	String name = c.getString(c.getColumnIndex("ref_name"));
-		        	long timeCreated = c.getInt(c.getColumnIndex("time_created"));
+		        	long timeCreated = c.getLong(c.getColumnIndex("time_created"));
 		        	String refName = c.getString(c.getColumnIndex("ref_name"));
 		        	if ((timeCreated > time) || (refName.equals(Reference.CURRENT_REF_FILENAME)))
 		        	{
@@ -384,7 +384,7 @@ public class ReferenceDBHelper
 		        for (int i = 0; i < numRows; ++i)
 		        {
 		        	String name = c.getString(c.getColumnIndex("ref_label"));
-		        	long timeCreated = c.getInt(c.getColumnIndex("time_created"));
+		        	long timeCreated = c.getLong(c.getColumnIndex("time_created"));
 		        	if (timeCreated > time)
 		        	{
 		        		ret.add(name);


### PR DESCRIPTION
The following exception was seen on xdaedition 1.14.0.0 (and earlier versions) during application startup:

```
10-13 17:11:09.504  9102  9102 I ReferenceDBHelper: Reference store
10-13 17:11:09.504  9102  9102 I ReferenceDBHelper: Reference ref_boot created 36 s  (Wl: 0 elements; KWl: 0elements; NetS: 5 elements; Alrm: 3 elements; Proc: 0 elements; Oth: 0 elements; CPU: 12 elements)
10-13 17:11:09.504  9102  9102 I ReferenceDBHelper: Reference ref_unplugged created 39 d 5 h 38 m 54 s  (Wl: 0 elements; KWl: 54elements; NetS: 23 elements; Alrm: 16 elements; Proc: 0 elements; Oth: 8 elements; CPU: 13 elements)
10-13 17:11:09.504  9102  9102 I ReferenceDBHelper: Reference ref_charged created 39 d 5 h 39 m 42 s  (Wl: 1 elements; KWl: 54elements; NetS: 23 elements; Alrm: 16 elements; Proc: 0 elements; Oth: 8 elements; CPU: 13 elements)
10-13 17:11:09.514  9102  9102 I ReferenceDBHelper: Reference ref_screen_off created 39 d 23 h 55 m 28 s  (Wl: 22 elements; KWl: 54elements; NetS: 23 elements; Alrm: 16 elements; Proc: 12 elements; Oth: 9 elements; CPU: 13 elements)
10-13 17:11:09.514  9102  9102 I ReferenceDBHelper: Reference ref_current created 40 d 7 h 41 m 18 s  (Wl: 26 elements; KWl: 54elements; NetS: 23 elements; Alrm: 16 elements; Proc: 13 elements; Oth: 9 elements; CPU: 13 elements)
10-13 17:11:09.514  9102  9102 I StatsActivity: OnResume called
10-13 17:11:09.514  9102  9102 I ReferenceStore: Populating cache
10-13 17:11:09.514  9102  9102 I ReferenceStore: Added ref ref_boot
10-13 17:11:09.524  9102  9102 I ReferenceStore: Added ref ref_current
10-13 17:11:09.524  9102  9102 I ReferenceStore: Finished populating cache
10-13 17:11:09.524  9102  9102 D AndroidRuntime: Shutting down VM
10-13 17:11:09.524  9102  9102 W dalvikvm: threadid=1: thread exiting with uncaught exception (group=0x40e37438)
10-13 17:11:09.524  9102  9102 E AndroidRuntime: FATAL EXCEPTION: main
10-13 17:11:09.524  9102  9102 E AndroidRuntime: java.lang.RuntimeException: Unable to resume activity {com.asksven.betterbatterystats_xdaedition/com.asksven.betterbatterystats.StatsActivity}: java.lang.IndexOutOfBoundsException: Invalid index 1, size is 1
10-13 17:11:09.524  9102  9102 E AndroidRuntime:    at android.app.ActivityThread.performResumeActivity(ActivityThread.java:2628)
10-13 17:11:09.524  9102  9102 E AndroidRuntime:    at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:2667)
10-13 17:11:09.524  9102  9102 E AndroidRuntime:    at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2127)
10-13 17:11:09.524  9102  9102 E AndroidRuntime:    at android.app.ActivityThread.access$600(ActivityThread.java:133)
10-13 17:11:09.524  9102  9102 E AndroidRuntime:    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1221)
10-13 17:11:09.524  9102  9102 E AndroidRuntime:    at android.os.Handler.dispatchMessage(Handler.java:99)
10-13 17:11:09.524  9102  9102 E AndroidRuntime:    at android.os.Looper.loop(Looper.java:137)
10-13 17:11:09.524  9102  9102 E AndroidRuntime:    at android.app.ActivityThread.main(ActivityThread.java:4912)
10-13 17:11:09.524  9102  9102 E AndroidRuntime:    at java.lang.reflect.Method.invokeNative(Native Method)
10-13 17:11:09.524  9102  9102 E AndroidRuntime:    at java.lang.reflect.Method.invoke(Method.java:511)
10-13 17:11:09.524  9102  9102 E AndroidRuntime:    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:789)
10-13 17:11:09.524  9102  9102 E AndroidRuntime:    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:556)
10-13 17:11:09.524  9102  9102 E AndroidRuntime:    at dalvik.system.NativeStart.main(Native Method)
10-13 17:11:09.524  9102  9102 E AndroidRuntime: Caused by: java.lang.IndexOutOfBoundsException: Invalid index 1, size is 1
10-13 17:11:09.524  9102  9102 E AndroidRuntime:    at java.util.ArrayList.throwIndexOutOfBoundsException(ArrayList.java:251)
10-13 17:11:09.524  9102  9102 E AndroidRuntime:    at java.util.ArrayList.remove(ArrayList.java:399)
10-13 17:11:09.524  9102  9102 E AndroidRuntime:    at com.asksven.betterbatterystats.adapters.ReferencesAdapter.refreshFromSpinner(ReferencesAdapter.java:73)
10-13 17:11:09.524  9102  9102 E AndroidRuntime:    at com.asksven.betterbatterystats.StatsActivity.refreshSpinners(StatsActivity.java:903)
10-13 17:11:09.524  9102  9102 E AndroidRuntime:    at com.asksven.betterbatterystats.StatsActivity.doRefresh(StatsActivity.java:954)
10-13 17:11:09.524  9102  9102 E AndroidRuntime:    at com.asksven.betterbatterystats.StatsActivity.onResume(StatsActivity.java:541)
10-13 17:11:09.524  9102  9102 E AndroidRuntime:    at android.app.Instrumentation.callActivityOnResume(Instrumentation.java:1184)
10-13 17:11:09.524  9102  9102 E AndroidRuntime:    at android.app.Activity.performResume(Activity.java:5132)
10-13 17:11:09.524  9102  9102 E AndroidRuntime:    at android.app.ActivityThread.performResumeActivity(ActivityThread.java:2611)
10-13 17:11:09.524  9102  9102 E AndroidRuntime:    ... 12 more
10-13 17:11:09.534   722  4524 W ActivityManager:   Force finishing activity com.asksven.betterbatterystats_xdaedition/com.asksven.betterbatterystats.StatsActivity
```

sqlite says:

```
sqlite> select time_created,ref_name,ref_label from samples order by time_created;
36906|ref_boot|Boot
3389934796|ref_unplugged|Unplugged
3389982064|ref_charged|Charged
3455728601|ref_screen_off|Screen Off
3483678536|ref_current|Current
```

As it turns out, these time_created values, which the app obtains via SystemClock.elapsedRealtime(), do not fit in a signed 32-bit integer.  It is necessary to use getLong() to extract this field from SQLite, as time_elapsed will exceed Integer.MAX_VALUE in about 25 days, and then getInt() will start returning negative numbers.  Negative values of timeCreated will cause (timeCreated > time) to be false for most reasonable values of time (including 0), resulting in much chaos.

The phone on which this problem was seen had not been rebooted in 40 days:

```
$ adb shell uptime
up time: 40 days, 09:30:28, idle time: 26 days, 09:46:03, sleep time: 26 days, 16:10:16
```

BTW: I was not successful in making a local build from the current head of tree, as the AndroidCommon repo is missing RootShell.java.  Could you please push your latest changes and make sure the tree is buildable from a "clean" checkout?

Thanks.
