### PR TITLE
Duplicate subexpressions in GraphableBarsPlot.java

### DIFF
--- a/BetterBatteryStats/src/com/asksven/betterbatterystats/widgets/GraphableBarsPlot.java
+++ b/BetterBatteryStats/src/com/asksven/betterbatterystats/widgets/GraphableBarsPlot.java
@@ -160,7 +160,7 @@ public class GraphableBarsPlot extends ImageView
         	float posY = (ratioY * (ymax - ymin)) + ymin;
         	//Log.i(TAG, "Translated to posX=" + posX + ", posY=" + posY);
         	//canvas.drawCircle(posX, ymax - posY, 2, sPaint); //Line(posX, ymax, posX, ymax - posY, sPaint);
-        	if ((prevY != -1) && (prevY != -1))
+        	if ((prevX != -1) && (prevY != -1))
         	{
         		// connect dots
         		canvas.drawLine(prevX, ymax - prevY, posX, ymax - posY, sPaint);


### PR DESCRIPTION
`prevY != -1` is repeated. Looks like this should be `prevX != -1`.
