### PR TITLE
Added minimum threshold to store charged reference

### DIFF
--- a/app/src/main/java/com/asksven/betterbatterystats/services/WriteUnpluggedReferenceService.java
+++ b/app/src/main/java/com/asksven/betterbatterystats/services/WriteUnpluggedReferenceService.java
@@ -18,7 +18,9 @@ package com.asksven.betterbatterystats.services;
 import android.app.IntentService;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.SharedPreferences;
 import android.os.IBinder;
+import android.preference.PreferenceManager;
 import android.util.Log;
 
 import com.asksven.android.common.utils.DateUtils;
@@ -75,7 +77,10 @@ public class WriteUnpluggedReferenceService extends IntentService
 
 			Log.i(TAG, "Bettery level on uplug is " + level );
 
-			if (level == 1)
+			SharedPreferences sharedPrefs = PreferenceManager.getDefaultSharedPreferences(this);
+			double level_threshold = sharedPrefs.getInt("battery_charged_minimum_threshold", 100) / 100.0;
+
+			if (level >= level_threshold)
 			{
 				try
 				{

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -206,6 +206,8 @@
     <string name="pref_enable_watchdog_summary">Enables watchdog processing</string>
     <string name="pref_watchdog_on_unlock_title">Watchdog on unlock</string>
     <string name="pref_watchdog_on_unlock_summary">Watchdog runs upon \'unlock\' (else on \'screen on\')</string>
+    <string name="pref_charged_trigger_percentage_title">Minimum percentage that counts as charged</string>
+    <string name="pref_charged_trigger_percentage_summary">If battery is over this percentage when charging cable is unplugged, then Since Charged reference is stored</string>
     <string name="pref_section_warnings">Warnings</string>
     <string name="pref_watchdog_awake_threshold_title">Awake threshold</string>
     <string name="pref_watchdog_awake_threshold_summary">Threshold for warning (awake / total)</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -343,6 +343,16 @@
                 android:key="ignore_system_app"
                 android:summary="@string/pref_ignore_system_app_summary"
                 android:title="@string/pref_ignore_system_app_title" />
+            <com.asksven.betterbatterystats.contrib.SeekBarPreference
+                android:defaultValue="100"
+                android:key="battery_charged_minimum_threshold"
+                android:max="100"
+                android:summary="@string/pref_charged_trigger_percentage_summary"
+                android:title="@string/pref_charged_trigger_percentage_title"
+                robobunny:interval="1"
+                robobunny:min="0"
+                robobunny:unitsLeft=""
+                robobunny:unitsRight="%" />
             <CheckBoxPreference
                 android:defaultValue="false"
                 android:key="developer"


### PR DESCRIPTION
Recently I started using an app that prevents my phone from getting charged over a certain percentage (to prevent battery wear). But BBS doesn't store the "Charged" reference unless the battery reaches 100%, so I end up with incorrect stats in BBS.
This pull request is my attempt at fixing this problem.