### PR TITLE
small bug fix: missing else

### DIFF
--- a/app/src/main/java/com/asksven/android/common/privateapiproxies/BatteryStatsProxy.java
+++ b/app/src/main/java/com/asksven/android/common/privateapiproxies/BatteryStatsProxy.java
@@ -3161,6 +3161,7 @@ public class BatteryStatsProxy
 						myStats.add(myData);
 
                     }
+                    else 
                     {
 						myData = new NetworkUsage(uid, bytesReceived, bytesSent);
 						// try resolving names


### PR DESCRIPTION
At the end of `getNetworkUsageStats`, a NetworkUsage will be created for `bytesReceived`, `bytesSent`. But there seems to be a missing `else`. Not sure if this is intentional. 